### PR TITLE
Fix workflow errors to prevent test failures

### DIFF
--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -17,13 +17,15 @@ jobs:
         with:
           toolchain: stable
           components: rustfmt, clippy
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
             dnsraw/target
           key: ${{ runner.os }}-cargo-${{ hashFiles('dnsraw/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
       - name: Build
         working-directory: dnsraw
         run: cargo build --verbose
@@ -36,12 +38,15 @@ jobs:
       - name: Check formatting
         working-directory: dnsraw
         run: cargo fmt -- --check
+      - name: Install cargo-tarpaulin
+        run: cargo install cargo-tarpaulin
       - name: Code coverage
         working-directory: dnsraw
         run: cargo tarpaulin --skip-clean --out Xml
         continue-on-error: true
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
+        if: success() || failure()
         with:
           name: coverage-report
           path: dnsraw/cobertura.xml


### PR DESCRIPTION
- Upgrade actions/cache from v3 to v4 for consistency
- Add restore-keys to cache configuration for better cache utilization
- Add cargo-tarpaulin installation step before running coverage
- Add conditional upload artifact to run even if coverage fails